### PR TITLE
Fix SerializeReference array initialization

### DIFF
--- a/Assets/InspectorEvents/Core/InspectorEvent.cs
+++ b/Assets/InspectorEvents/Core/InspectorEvent.cs
@@ -36,12 +36,14 @@ public sealed class InspectorEvent {
 
 [Serializable]
 public sealed class InspectorEvent<TEvent> {
+    // ReSharper disable UseArrayEmptyMethod
     [SerializeReference] 
     IInspectorEventFilter<TEvent>[] filters = new IInspectorEventFilter<TEvent>[0];
     
     [PropertySpace]
     [SerializeReference] 
     IInspectorEventHandler<TEvent>[] handlers = new IInspectorEventHandler<TEvent>[0];
+    // ReSharper restore UseArrayEmptyMethod
 
 #if UNITY_EDITOR
     [SerializeReference, HideInInspector]

--- a/Assets/InspectorEvents/Core/InspectorEvent.cs
+++ b/Assets/InspectorEvents/Core/InspectorEvent.cs
@@ -8,11 +8,11 @@ namespace InspectorEvents.Core;
 [Serializable]
 public sealed class InspectorEvent {
     [SerializeReference] 
-    IInspectorEventFilter[] filters = Array.Empty<IInspectorEventFilter>();
+    IInspectorEventFilter[] filters = new IInspectorEventFilter[0];
     
     [PropertySpace]
     [SerializeReference] 
-    IInspectorEventHandler[] handlers = Array.Empty<IInspectorEventHandler>();
+    IInspectorEventHandler[] handlers = new IInspectorEventHandler[0];
 
     public void Invoke() {
         if (!EvaluateFilters()) 
@@ -37,11 +37,11 @@ public sealed class InspectorEvent {
 [Serializable]
 public sealed class InspectorEvent<TEvent> {
     [SerializeReference] 
-    IInspectorEventFilter<TEvent>[] filters = Array.Empty<IInspectorEventFilter<TEvent>>();
+    IInspectorEventFilter<TEvent>[] filters = new IInspectorEventFilter<TEvent>[0];
     
     [PropertySpace]
     [SerializeReference] 
-    IInspectorEventHandler<TEvent>[] handlers = Array.Empty<IInspectorEventHandler<TEvent>>();
+    IInspectorEventHandler<TEvent>[] handlers = new IInspectorEventHandler<TEvent>[0];
 
 #if UNITY_EDITOR
     [SerializeReference, HideInInspector]

--- a/Assets/InspectorEvents/Handlers/IEH_DelayCall.cs
+++ b/Assets/InspectorEvents/Handlers/IEH_DelayCall.cs
@@ -12,7 +12,7 @@ public sealed class IEH_DelayCall : IInspectorEventHandler {
     [SerializeField, ShowIf(nameof(randomize))] Vector2 delaySecondsRange;
     [PropertySpace]
     [SerializeReference] 
-    IInspectorEventHandler[] handlers = Array.Empty<IInspectorEventHandler>();
+    IInspectorEventHandler[] handlers = new IInspectorEventHandler[0];
     
     public void Handle() {
         var delay = randomize ? UnityEngine.Random.Range(delaySecondsRange.x, delaySecondsRange.y) : delaySeconds;
@@ -39,7 +39,7 @@ public sealed class IEH_DelayCall<TEvent> : IInspectorEventHandler<TEvent> {
     [SerializeField, ShowIf(nameof(randomize))] Vector2 delaySecondsRange;
     [PropertySpace]
     [SerializeReference] 
-    IInspectorEventHandler<TEvent>[] handlers = Array.Empty<IInspectorEventHandler<TEvent>>();
+    IInspectorEventHandler<TEvent>[] handlers = new IInspectorEventHandler<TEvent>[0];
     
     public void Handle(in TEvent evt) {
         var delay = randomize ? UnityEngine.Random.Range(delaySecondsRange.x, delaySecondsRange.y) : delaySeconds;

--- a/Assets/InspectorEvents/Handlers/IEH_DelayCall.cs
+++ b/Assets/InspectorEvents/Handlers/IEH_DelayCall.cs
@@ -12,6 +12,7 @@ public sealed class IEH_DelayCall : IInspectorEventHandler {
     [SerializeField, ShowIf(nameof(randomize))] Vector2 delaySecondsRange;
     [PropertySpace]
     [SerializeReference] 
+    // ReSharper disable once UseArrayEmptyMethod
     IInspectorEventHandler[] handlers = new IInspectorEventHandler[0];
     
     public void Handle() {
@@ -39,6 +40,7 @@ public sealed class IEH_DelayCall<TEvent> : IInspectorEventHandler<TEvent> {
     [SerializeField, ShowIf(nameof(randomize))] Vector2 delaySecondsRange;
     [PropertySpace]
     [SerializeReference] 
+    // ReSharper disable once UseArrayEmptyMethod
     IInspectorEventHandler<TEvent>[] handlers = new IInspectorEventHandler<TEvent>[0];
     
     public void Handle(in TEvent evt) {

--- a/Assets/InspectorEvents/Handlers/IEH_FilterCall.cs
+++ b/Assets/InspectorEvents/Handlers/IEH_FilterCall.cs
@@ -6,10 +6,12 @@ namespace InspectorEvents.Handlers;
 
 [Serializable]
 public sealed class IEH_FilterCall : IInspectorEventHandler {
+    // ReSharper disable UseArrayEmptyMethod
     [SerializeReference] 
     IInspectorEventFilter[] filters = new IInspectorEventFilter[0];
     [SerializeReference] 
     IInspectorEventHandler[] handlers = new IInspectorEventHandler[0];
+    // ReSharper restore UseArrayEmptyMethod
     
     public void Handle() {
         // ReSharper disable once LoopCanBeConvertedToQuery
@@ -27,10 +29,12 @@ public sealed class IEH_FilterCall : IInspectorEventHandler {
 
 [Serializable]
 public sealed class IEH_FilterCall<TEvent> : IInspectorEventHandler<TEvent> {
+    // ReSharper disable UseArrayEmptyMethod
     [SerializeReference] 
     IInspectorEventFilter<TEvent>[] filters = new IInspectorEventFilter<TEvent>[0];
     [SerializeReference] 
     IInspectorEventHandler<TEvent>[] handlers = new IInspectorEventHandler<TEvent>[0];
+    // ReSharper restore UseArrayEmptyMethod
     
     public void Handle(in TEvent evt) {
         // ReSharper disable once LoopCanBeConvertedToQuery

--- a/Assets/InspectorEvents/Handlers/IEH_FilterCall.cs
+++ b/Assets/InspectorEvents/Handlers/IEH_FilterCall.cs
@@ -7,9 +7,9 @@ namespace InspectorEvents.Handlers;
 [Serializable]
 public sealed class IEH_FilterCall : IInspectorEventHandler {
     [SerializeReference] 
-    IInspectorEventFilter[] filters = Array.Empty<IInspectorEventFilter>();
+    IInspectorEventFilter[] filters = new IInspectorEventFilter[0];
     [SerializeReference] 
-    IInspectorEventHandler[] handlers = Array.Empty<IInspectorEventHandler>();
+    IInspectorEventHandler[] handlers = new IInspectorEventHandler[0];
     
     public void Handle() {
         // ReSharper disable once LoopCanBeConvertedToQuery
@@ -28,9 +28,9 @@ public sealed class IEH_FilterCall : IInspectorEventHandler {
 [Serializable]
 public sealed class IEH_FilterCall<TEvent> : IInspectorEventHandler<TEvent> {
     [SerializeReference] 
-    IInspectorEventFilter<TEvent>[] filters = Array.Empty<IInspectorEventFilter<TEvent>>();
+    IInspectorEventFilter<TEvent>[] filters = new IInspectorEventFilter<TEvent>[0];
     [SerializeReference] 
-    IInspectorEventHandler<TEvent>[] handlers = Array.Empty<IInspectorEventHandler<TEvent>>();
+    IInspectorEventHandler<TEvent>[] handlers = new IInspectorEventHandler<TEvent>[0];
     
     public void Handle(in TEvent evt) {
         // ReSharper disable once LoopCanBeConvertedToQuery


### PR DESCRIPTION
## Summary
- Replaced `Array.Empty<T>()` with `new T[0]` for all `[SerializeReference]` array fields.
- Applied the change to `InspectorEvent`, `IEH_DelayCall`, and `IEH_FilterCall` for both generic and non-generic variants.

## Testing
- Verified there are no remaining `Array.Empty` usages under `Assets/InspectorEvents`.
- Confirmed the targeted `[SerializeReference]` fields were updated and `git diff --check` reported no patch-format issues.